### PR TITLE
Ropsten deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,26 @@
-node_modules
-build
-*.log
 lib
-secrets.json
+
+# Coverage directory used by tools like istanbul
 coverage
 coverage.json
-allFiredEvents
-scTopics
 coverageEnv
 
+# Dependency directory
+node_modules
+
+# Infura deployment configuration
+secrets.json
+
+# Logs
+*.log
+
+# Runtime data
+allFiredEvents
+scTopics
+
+# Truffle build directory
+build
+
+# Zeppelin OS
 .zos.session
 zos.development.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2673,7 +2673,7 @@
     },
     "ethereumjs-block": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "requires": {
         "async": "^2.0.1",
@@ -4809,7 +4809,7 @@
     },
     "level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
         "inherits": "^2.0.1",
@@ -4820,7 +4820,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4842,7 +4842,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5080,9 +5080,9 @@
       "dev": true
     },
     "merkle-patricia-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
-      "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "requires": {
         "async": "^1.4.2",
         "ethereumjs-util": "^5.0.0",
@@ -5096,7 +5096,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -7480,7 +7480,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-          "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
         },
         "web3": {
           "version": "0.18.4",
@@ -8071,11 +8071,11 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
-          "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9"
+          "from": "git+https://github.com/debris/bignumber.js.git#master"
         },
         "web3": {
           "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+          "resolved": "http://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
             "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",

--- a/truffle.js
+++ b/truffle.js
@@ -1,11 +1,15 @@
+
 require('babel-register')
 require('babel-polyfill')
+
+const HDWalletProvider = require("truffle-hdwallet-provider");
+const secrets = require('./secrets.json');
 
 module.exports = {
   networks: {
     development: {
       host: 'localhost',
-      port: 8546,
+      port: 8545,
       network_id: '*', // Match any network id
       gas: 6000000,
       gasPrice: 0x01
@@ -16,6 +20,12 @@ module.exports = {
       port: 8546,
       gas: 0xfffffffffff,
       gasPrice: 0x01
-    }
+    },
+    ropsten: {
+      provider: function() {
+        return new HDWalletProvider(secrets.mnemonic, "https://ropsten.infura.io/<secrets.infura_apikey>")
+      },
+      network_id: 3
+    }   
   }
 }

--- a/zos.ropsten.json
+++ b/zos.ropsten.json
@@ -1,0 +1,67 @@
+{
+  "contracts": {
+    "BasicPushOracle": {
+      "address": "0x60f72f4412183787cc91ce784cdd077251f5eb01",
+      "constructorCode": "608060405234801561001057600080fd5b50611cae806100206000396000f300",
+      "bodyBytecodeHash": "0923dcf2aae34681636485db03fe59e51f077137659ccc895a410a6f19d716b7",
+      "bytecodeHash": "561dc39649bd023bd8e5d10285d90a989fa0ab6eb2faec4872b93e2404710cce"
+    },
+    "PaidMultiOracle": {
+      "address": "0x11d0644e3c7b212409ab9149833c6ae7543d041a",
+      "constructorCode": "608060405233600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550611b27806100546000396000f300",
+      "bodyBytecodeHash": "7f441b8374c98ab6145196a94f43720ae947a4092397cf48e49b22544169c4b4",
+      "bytecodeHash": "bedc59c122041c3ec0c1f896c1016a1f3b49c00dd6810e70b8ef2777c5cc215c"
+    },
+    "SignedMultiOracle": {
+      "address": "0x035534a6012231209fbbd92d20935ad37b4f47e7",
+      "constructorCode": "608060405233600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550611881806100546000396000f300",
+      "bodyBytecodeHash": "841c1f0bcbb58abff35cb3e998b3a5804cd1ef1ef8725e128827ebcce2a5e2e8",
+      "bytecodeHash": "527b8b11a635130948fc7085dfda4d20d93bf63ab89adc7a1406c35f4117b271"
+    },
+    "BasicOracle": {
+      "address": "0x7b12309780cc4fc41a45bd075458192bbd6abf5a",
+      "constructorCode": "608060405234801561001057600080fd5b5061123b806100206000396000f300",
+      "bodyBytecodeHash": "788fe0bf364952ce4a2c8d8b4723296bde92e440da0f12bd8ac8324201bd2f17",
+      "bytecodeHash": "1242c6d13391b82be722364b3a60918c0937289ee3d36d964179e341b6478c86"
+    },
+    "MultiOracle": {
+      "address": "0x7ad7265a60daf81e99401359904ce3b591cd1dd0",
+      "constructorCode": "608060405233600160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555061145f806100546000396000f300",
+      "bodyBytecodeHash": "cffa134dd9caf5466b2cb12d7d49b572cc8b686e91f055c9d0f24403bb9639c2",
+      "bytecodeHash": "75a02604e1d3d559c6c87256cc6080b61a08b8bc6683f65ef62647d8fe5869dd"
+    },
+    "SignedOracle": {
+      "address": "0x9b211d7eb89faa38e3bd1b12b793e0a38068115a",
+      "constructorCode": "608060405234801561001057600080fd5b50611a0c806100206000396000f300",
+      "bodyBytecodeHash": "6f1fec9cd22069260590656677d1519d32e2de249a3bbfbd31c17fee1d407af1",
+      "bytecodeHash": "b17f49d12800a37a4900968a7e63360d887f53836328a63966192683c83d1bbb"
+    },
+    "PaidOracle": {
+      "address": "0x8df7808372cb4b65c014e402f9da9e1fc5a14e93",
+      "constructorCode": "608060405234801561001057600080fd5b50611915806100206000396000f300",
+      "bodyBytecodeHash": "7a6af0bb5835334dab796a8a4064000911a435f64bd55331b085e403bf1b3db4",
+      "bytecodeHash": "91e6387f5767104a9f9449551d86ea227a045138371afc5b796f515ac039625e"
+    },
+    "SignedPushOracle": {
+      "address": "0xf5a9a3059289284e760bae541fb2eabe8d3485ad",
+      "constructorCode": "608060405234801561001057600080fd5b5061247f806100206000396000f300",
+      "bodyBytecodeHash": "fe5c774095769ea0a54ebc6817fd3e4bc3249a3de7e3e88892892b5ea3d876ba",
+      "bytecodeHash": "7e4a46fd16dcd0daeca41a41e53165ceabe5b7b8eb7e9b7b598d15f3cec34a70"
+    },
+    "MedianOracle": {
+      "address": "0xea4dd448a0261eaf9dec02766c4a7e18184d47e5",
+      "constructorCode": "608060405234801561001057600080fd5b50612be6806100206000396000f300",
+      "bodyBytecodeHash": "9d33012eba5f54e91a7f328a860a1f16e337b956d58d571163f3fea58d2e7dff",
+      "bytecodeHash": "b34f185a9b3e82b6d6a2939cef5940c86207221e59581da306594c0d83fd74f3"
+    }
+  },
+  "lib": true,
+  "frozen": false,
+  "package": {
+    "address": "0x6a00d11d0e59155a0941c67fae31c3846eb2f6e1"
+  },
+  "provider": {
+    "address": "0x60ea75d3e286ffe017442911ca7f4fb5fd9fbf71"
+  },
+  "version": "0.1.0"
+}


### PR DESCRIPTION
We may want to redo the Ropsten deploy with the ZOS 2.0 upgrades, but maybe wanna keep the changes to the gitignore and truffle config files.